### PR TITLE
Implement Kotlinx immutable collections

### DIFF
--- a/android-module.gradle
+++ b/android-module.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 31
+    compileSdk 33
     defaultConfig {
         minSdk 21
-        targetSdk 31
+        targetSdk 33
         versionCode 1
         versionName "1.0"
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,13 +4,14 @@ plugin-ktlint = "10.2.1"
 plugin-maven = "0.22.0"
 
 kotlin = "1.8.20"
+kotlinx-immutable-collections = "0.3.5"
 
 ksp = "1.8.20-1.0.10"
 caseFormat = "0.2.0"
 konsumeXml = "1.0"
 
 appCompat = "1.4.1"
-compose = "1.3.0"
+compose = "1.4.3"
 composeCompiler = "1.4.5"
 composeActivity = "1.4.0"
 composeMultiplatform = "1.4.0"
@@ -24,6 +25,7 @@ plugin-maven = { module = "com.vanniktech:gradle-maven-publish-plugin", version.
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 plugin-ksp = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 plugin-compose-multiplatform = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "composeMultiplatform" }
+kotlinx-immutable-collections = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx-immutable-collections" }
 
 ksp = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 caseFormat = { module = "com.fleshgrinder.kotlin:case-format", version.ref = "caseFormat" }
@@ -38,4 +40,4 @@ compose-material = { module = "androidx.compose.material:material", version.ref 
 test-junit = { module = "androidx.test.ext:junit-ktx", version.ref = "test-junit" }
 
 [bundles]
-plugins = ["plugin-android", "plugin-ktlint", "plugin-maven", "plugin-kotlin", "plugin-ksp", "plugin-compose-multiplatform"]
+plugins = ["plugin-android", "plugin-ktlint", "plugin-maven", "plugin-kotlin", "plugin-ksp", "plugin-compose-multiplatform", "kotlinx-immutable-collections"]

--- a/lyricist-processor-xml/src/main/java/cafe/adriel/lyricist/processor/xml/internal/LyricistXmlSymbolProcessor.kt
+++ b/lyricist-processor-xml/src/main/java/cafe/adriel/lyricist/processor/xml/internal/LyricistXmlSymbolProcessor.kt
@@ -105,12 +105,14 @@ internal class LyricistXmlSymbolProcessor(
                 |
                 |import androidx.compose.runtime.Composable
                 |import androidx.compose.runtime.ProvidableCompositionLocal
-                |import androidx.compose.runtime.staticCompositionLocalOf
+                |import androidx.compose.runtime.compositionLocalOf
                 |import androidx.compose.ui.text.intl.Locale
                 |import cafe.adriel.lyricist.Lyricist
                 |import cafe.adriel.lyricist.LanguageTag
                 |import cafe.adriel.lyricist.rememberStrings
                 |import cafe.adriel.lyricist.ProvideStrings
+                |import kotlinx.collections.immutable.ImmutableMap
+                |import kotlinx.collections.immutable.persistentMapOf
                 |
                 |public data class $fileName(
                 |$values
@@ -120,11 +122,11 @@ internal class LyricistXmlSymbolProcessor(
                 |$localesOutput
                 |}
                 |
-                |public val $stringsName: Map<LanguageTag, $fileName> = mapOf(
+                |public val $stringsName: ImmutableMap<LanguageTag, $fileName> = persistentMapOf(
                 |$translationMappingOutput
                 |)
                 |
-                |public val Local$fileName: ProvidableCompositionLocal<$fileName> = staticCompositionLocalOf { $defaultStringsOutput }
+                |public val Local$fileName: ProvidableCompositionLocal<$fileName> = compositionLocalOf { $defaultStringsOutput }
                 |
                 |@Composable
                 |public fun remember$fileName(

--- a/lyricist-processor/src/main/java/cafe/adriel/lyricist/processor/internal/LyricistSymbolProcessor.kt
+++ b/lyricist-processor/src/main/java/cafe/adriel/lyricist/processor/internal/LyricistSymbolProcessor.kt
@@ -84,9 +84,11 @@ internal class LyricistSymbolProcessor(
                 |import cafe.adriel.lyricist.LanguageTag
                 |import cafe.adriel.lyricist.rememberStrings
                 |import cafe.adriel.lyricist.ProvideStrings
+                |import kotlinx.collections.immutable.ImmutableMap
+                |import kotlinx.collections.immutable.persistentMapOf
                 |$packagesOutput
                 |
-                |$visibility val $stringsName: Map<LanguageTag, $stringsClassOutput> = mapOf(
+                |$visibility val $stringsName: ImmutableMap<LanguageTag, $stringsClassOutput> = persistentMapOf(
                 |$translationMappingOutput
                 |)
                 |

--- a/lyricist/build.gradle.kts
+++ b/lyricist/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 api(project(":lyricist-core"))
+                api(libs.kotlinx.immutable.collections)
                 compileOnly(compose.runtime)
                 compileOnly(compose.ui)
             }

--- a/lyricist/src/commonMain/kotlin/cafe/adriel/lyricist/Lyricist.kt
+++ b/lyricist/src/commonMain/kotlin/cafe/adriel/lyricist/Lyricist.kt
@@ -3,10 +3,11 @@ package cafe.adriel.lyricist
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import kotlinx.collections.immutable.ImmutableMap
 
 public class Lyricist<T>(
     private val defaultLanguageTag: LanguageTag,
-    private val translations: Map<LanguageTag, T>
+    private val translations: ImmutableMap<LanguageTag, T>
 ) {
 
     public var languageTag: LanguageTag by mutableStateOf(defaultLanguageTag)

--- a/lyricist/src/commonMain/kotlin/cafe/adriel/lyricist/LyricistUtils.kt
+++ b/lyricist/src/commonMain/kotlin/cafe/adriel/lyricist/LyricistUtils.kt
@@ -5,10 +5,12 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.remember
 import androidx.compose.ui.text.intl.Locale
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.persistentMapOf
 
 @Composable
 public fun <T> rememberStrings(
-    translations: Map<LanguageTag, T>,
+    translations: ImmutableMap<LanguageTag, T> = persistentMapOf(),
     languageTag: LanguageTag = Locale.current.toLanguageTag()
 ): Lyricist<T> =
     remember { Lyricist(languageTag, translations) }


### PR DESCRIPTION
Because `Map<*>` is a mutable type, it is unstable and badly affects compose performance, we should use [Kotlin immutable collections](https://github.com/Kotlin/kotlinx.collections.immutable)' `ImmutableMap` instead.

Refer: https://betterprogramming.pub/optimizing-recomposition-in-jetpack-compose-stability-system-f8ec0c92de33