### PR TITLE
Inline XML plain string resource references

### DIFF
--- a/lyricist-processor-xml/src/main/java/cafe/adriel/lyricist/processor/xml/internal/ktx/Xml.kt
+++ b/lyricist-processor-xml/src/main/java/cafe/adriel/lyricist/processor/xml/internal/ktx/Xml.kt
@@ -43,8 +43,9 @@ internal fun File.getXmlStrings(): ResourceValues {
 private fun ResourceValues.applyReplacements(): ResourceValues {
     val values = toMutableList()
 
-    // We need to do a late replacements because Konsume XML resolves everything "on-demand"
-    // so trying to replace value of "A" node in "B" while "B" is being resolved is impossible
+    // We need to do late replacements because Konsume XML resolves everything on-demand,
+    // there's no get("something") so trying to replace value of "A" node in "B" while "B" is
+    // being resolved is impossible
     for (replacement in replacements) {
         val index = values.indexOfFirst { (key, _) -> key == replacement }
         val (key, resource) = values[index]

--- a/lyricist-processor-xml/src/main/java/cafe/adriel/lyricist/processor/xml/internal/ktx/Xml.kt
+++ b/lyricist-processor-xml/src/main/java/cafe/adriel/lyricist/processor/xml/internal/ktx/Xml.kt
@@ -19,6 +19,9 @@ private const val TAG_STRING_ARRAY = "string-array"
 private const val TAG_PLURALS = "plurals"
 private const val TAG_ITEM = "item"
 
+private val ReplacementExpr = Regex("@string/(\\S+)")
+private var replacements = mutableListOf<String>()
+
 internal fun FileTreeWalk.filterXmlStringFiles(): Sequence<File> =
     filter {
         it.isFile &&
@@ -26,31 +29,82 @@ internal fun FileTreeWalk.filterXmlStringFiles(): Sequence<File> =
             it.parentFile.name.startsWith(VALUES_FOLDER_NAME, ignoreCase = true)
     }
 
-internal fun File.getXmlStrings(): List<Pair<ResourceName, StringResource>> =
-    konsumeXml()
+private typealias ResourceValues = List<Pair<ResourceName, StringResource>>
+
+internal fun File.getXmlStrings(): ResourceValues {
+    replacements = mutableListOf()
+    return konsumeXml()
         .child(TAG_RESOURCES) {
             getPlainStrings() + getStringArrays() + getPlurals()
         }
+        .applyReplacements()
+}
 
-private fun Konsumer.getPlainStrings(): List<Pair<String, StringResource>> =
+private fun ResourceValues.applyReplacements(): ResourceValues {
+    val values = toMutableList()
+
+    // We need to do a late replacements because Konsume XML resolves everything "on-demand"
+    // so trying to replace value of "A" node in "B" while "B" is being resolved is impossible
+    for (replacement in replacements) {
+        val index = values.indexOfFirst { (key, _) -> key == replacement }
+        val (key, resource) = values[index]
+        val replaced: StringResource = when (resource) {
+            is StringResource.PlainString -> resource.copy(
+                value = replaceResourceValueExpr(resource.value, values)
+            )
+            is StringResource.Plurals -> resource.copy(
+                value = resource.value.mapValues { (_, nodeText) ->
+                    replaceResourceValueExpr(nodeText, values)
+                }
+            )
+            is StringResource.StringArray -> resource.copy(
+                value = resource.value.map { nodeText -> replaceResourceValueExpr(nodeText, values) }
+            )
+        }
+
+        values[index] = key to replaced
+    }
+
+    return values
+}
+
+private fun replaceResourceValueExpr(currentValue: String, values: ResourceValues) =
+    ReplacementExpr.replace(currentValue) { match ->
+        val target = match.groupValues.last()
+        // Searches for `<string name="...">`
+        val (_, resource) = values.first { (name, _) -> name == target }
+        (resource as StringResource.PlainString).value
+    }
+
+private fun Konsumer.getPlainStrings(): ResourceValues =
     children(TAG_STRING) {
-        attributes[ATTRIBUTE_NAME] to StringResource.PlainString(
-            value = text()
+        val attr = attributes[ATTRIBUTE_NAME]
+        attr to StringResource.PlainString(
+            value = textWithReplacements(attr)
         )
     }
 
-private fun Konsumer.getStringArrays(): List<Pair<String, StringResource>> =
+private fun Konsumer.getStringArrays(): ResourceValues =
     children(TAG_STRING_ARRAY) {
-        attributes[ATTRIBUTE_NAME] to StringResource.StringArray(
-            value = children(TAG_ITEM) { text() }
+        val attr = attributes[ATTRIBUTE_NAME]
+        attr to StringResource.StringArray(
+            value = children(TAG_ITEM) { textWithReplacements(attr) }
         )
     }
 
-private fun Konsumer.getPlurals(): List<Pair<String, StringResource>> =
+private fun Konsumer.getPlurals(): ResourceValues =
     children(TAG_PLURALS) {
-        attributes[ATTRIBUTE_NAME] to StringResource.Plurals(
+        val attr = attributes[ATTRIBUTE_NAME]
+        attr to StringResource.Plurals(
             value = children(TAG_ITEM) {
-                Quantity.valueOf(attributes[ATTRIBUTE_QUANTITY].uppercase()) to text()
+                Quantity.valueOf(attributes[ATTRIBUTE_QUANTITY].uppercase()) to
+                    textWithReplacements(attr)
             }.toMap()
         )
+    }
+
+private fun Konsumer.textWithReplacements(attr: String): String = text()
+    .also { text ->
+        if (ReplacementExpr.containsMatchIn(text))
+            replacements.add(attr)
     }

--- a/lyricist-processor-xml/src/main/java/cafe/adriel/lyricist/processor/xml/internal/ktx/Xml.kt
+++ b/lyricist-processor-xml/src/main/java/cafe/adriel/lyricist/processor/xml/internal/ktx/Xml.kt
@@ -29,9 +29,9 @@ internal fun FileTreeWalk.filterXmlStringFiles(): Sequence<File> =
             it.parentFile.name.startsWith(VALUES_FOLDER_NAME, ignoreCase = true)
     }
 
-private typealias ResourceValues = List<Pair<ResourceName, StringResource>>
+private typealias ResourceNodes = List<Pair<ResourceName, StringResource>>
 
-internal fun File.getXmlStrings(): ResourceValues {
+internal fun File.getXmlStrings(): ResourceNodes {
     replacements = mutableListOf()
     return konsumeXml()
         .child(TAG_RESOURCES) {
@@ -40,7 +40,7 @@ internal fun File.getXmlStrings(): ResourceValues {
         .applyReplacements()
 }
 
-private fun ResourceValues.applyReplacements(): ResourceValues {
+private fun ResourceNodes.applyReplacements(): ResourceNodes {
     val values = toMutableList()
 
     // We need to do late replacements because Konsume XML resolves everything on-demand,
@@ -69,7 +69,7 @@ private fun ResourceValues.applyReplacements(): ResourceValues {
     return values
 }
 
-private fun replaceResourceValueExpr(currentValue: String, values: ResourceValues) =
+private fun replaceResourceValueExpr(currentValue: String, values: ResourceNodes) =
     ReplacementExpr.replace(currentValue) { match ->
         val target = match.groupValues.last()
         // Searches for `<string name="...">`
@@ -77,7 +77,7 @@ private fun replaceResourceValueExpr(currentValue: String, values: ResourceValue
         (resource as StringResource.PlainString).value
     }
 
-private fun Konsumer.getPlainStrings(): ResourceValues =
+private fun Konsumer.getPlainStrings(): ResourceNodes =
     children(TAG_STRING) {
         val attr = attributes[ATTRIBUTE_NAME]
         attr to StringResource.PlainString(
@@ -85,7 +85,7 @@ private fun Konsumer.getPlainStrings(): ResourceValues =
         )
     }
 
-private fun Konsumer.getStringArrays(): ResourceValues =
+private fun Konsumer.getStringArrays(): ResourceNodes =
     children(TAG_STRING_ARRAY) {
         val attr = attributes[ATTRIBUTE_NAME]
         attr to StringResource.StringArray(
@@ -93,7 +93,7 @@ private fun Konsumer.getStringArrays(): ResourceValues =
         )
     }
 
-private fun Konsumer.getPlurals(): ResourceValues =
+private fun Konsumer.getPlurals(): ResourceNodes =
     children(TAG_PLURALS) {
         val attr = attributes[ATTRIBUTE_NAME]
         attr to StringResource.Plurals(

--- a/sample-xml/src/main/res/values-pt/strings.xml
+++ b/sample-xml/src/main/res/values-pt/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="simple">Olá "mundo"</string>
     <string name="params">Parâmetros: %1$s, %2$d, %s, %d</string>
+    <string name="replacement">@string/simple denovo</string>
 
     <string-array name="array">
         <item>Abacate</item>

--- a/sample-xml/src/main/res/values/strings.xml
+++ b/sample-xml/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="simple">Hello "world"</string>
     <string name="params">Parameters: %1$s, %2$d, %s, %d</string>
+    <string name="replacement">@string/simple again</string>
 
     <string-array name="array">
         <item>Avocado</item>


### PR DESCRIPTION
Closes #17

This code should work now
```xml
<string name="avocado">Avocado</string>
<string name="nikocado">Nikocado @string/avocado</string>
```

<table>
<thead>
<th>Before</th>
<th>After</th>
<tbody>
<tr>
<td>

```kotlin
val avocado: String = "Avocado",
val nikocado: String = "Nikocado @string/avocado"
```

</td>
<td>

```kotlin
val avocado: String = "Avocado",
val nikocado: String = "Nikocado Avocado"
```

</td>
</tr>
</tbody>
</thead>
</table>

Note that this PR only resolves the plain string resource references, is planned that in the near future references to non-plain string references must be supported in a natural way like adding a `quantity` to the node when it references a plural.