### PR TITLE
feat(non-compose-accessors): add non compose accessors

### DIFF
--- a/lyricist-processor-compose/src/main/java/cafe/adriel/lyricist/processor/internal/LyricistSymbolProcessor.kt
+++ b/lyricist-processor-compose/src/main/java/cafe/adriel/lyricist/processor/internal/LyricistSymbolProcessor.kt
@@ -124,6 +124,10 @@ internal class LyricistSymbolProcessor(
                 |) {
                 |    ProvideStrings(lyricist, Local$fileName, content)
                 |}
+                |
+                |$visibility fun getLocale$fileName(locale: Locale = Locale.current): $stringsClassOutput {
+                |    return $stringsName[locale.toLanguageTag()] ?: $defaultStringsOutput
+                |}                
                 """.trimMargin().toByteArray()
             )
         }

--- a/lyricist-processor-xml/src/main/java/cafe/adriel/lyricist/processor/xml/internal/LyricistXmlSymbolProcessor.kt
+++ b/lyricist-processor-xml/src/main/java/cafe/adriel/lyricist/processor/xml/internal/LyricistXmlSymbolProcessor.kt
@@ -168,6 +168,14 @@ internal class LyricistXmlSymbolProcessor(
                     """.trimMargin().toByteArray()
                 )
             }
+            stream.write(
+                """
+                |
+                |public fun getLocale$fileName(locale: Locale = Locale.current): $fileName {
+                |    return $stringsName[locale.toLanguageTag()] ?: $defaultStringsOutput
+                |} 
+                """.trimMargin().toByteArray()
+            )
         }
     }
 

--- a/sample/src/main/java/cafe/adriel/lyricist/sample/MainActivity.kt
+++ b/sample/src/main/java/cafe/adriel/lyricist/sample/MainActivity.kt
@@ -1,6 +1,7 @@
 package cafe.adriel.lyricist.sample
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Arrangement
@@ -27,6 +28,7 @@ import cafe.adriel.lyricist.XmlStrings
 import cafe.adriel.lyricist.custompackage.LocalMultiModuleStrings
 import cafe.adriel.lyricist.custompackage.ProvideMultiModuleStrings
 import cafe.adriel.lyricist.custompackage.rememberMultiModuleStrings
+import cafe.adriel.lyricist.getLocaleStrings
 import cafe.adriel.lyricist.rememberStrings
 import cafe.adriel.lyricist.rememberXmlStrings
 import cafe.adriel.lyricist.sample.multimodule.strings.MultiModuleStrings
@@ -70,7 +72,14 @@ class MainActivity : ComponentActivity() {
                             SampleXmlStrings()
                         }
                     }
+
+                    item {
+                        Row(modifier = Modifier.padding(vertical = 16.dp)) {
+                            ShowToastButton()
+                        }
+                    }
                 }
+
                 Row(
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     modifier = Modifier
@@ -158,6 +167,23 @@ class MainActivity : ComponentActivity() {
             // List string
             Text(text = LocalXmlStrings.current.array.joinToString())
         }
+    }
+
+    @Composable
+    fun ShowToastButton(
+        modifier: Modifier = Modifier
+    ) {
+        Button(
+            onClick = {
+                showToast()
+            }, modifier = modifier
+        ) {
+            Text(text = "Show Toast")
+        }
+    }
+
+    private fun showToast() {
+        Toast.makeText(this, getLocaleStrings().nonComposeAlert, Toast.LENGTH_SHORT).show()
     }
 
     @Composable

--- a/sample/src/main/java/cafe/adriel/lyricist/sample/strings/EnStrings.kt
+++ b/sample/src/main/java/cafe/adriel/lyricist/sample/strings/EnStrings.kt
@@ -31,5 +31,7 @@ internal val EnStrings = Strings(
         "I have $value apples"
     },
 
-    list = listOf("Avocado", "Pineapple", "Plum")
+    list = listOf("Avocado", "Pineapple", "Plum"),
+
+    nonComposeAlert = "This is a sample toast",
 )

--- a/sample/src/main/java/cafe/adriel/lyricist/sample/strings/PtStrings.kt
+++ b/sample/src/main/java/cafe/adriel/lyricist/sample/strings/PtStrings.kt
@@ -31,5 +31,7 @@ internal val PtStrings = Strings(
         "Eu $value maças"
     },
 
-    list = listOf("Abacate", "Abacaxi", "Ameixa")
+    list = listOf("Abacate", "Abacaxi", "Ameixa"),
+
+    nonComposeAlert = "Este é um exemplo de brinde",
 )

--- a/sample/src/main/java/cafe/adriel/lyricist/sample/strings/Strings.kt
+++ b/sample/src/main/java/cafe/adriel/lyricist/sample/strings/Strings.kt
@@ -7,5 +7,6 @@ internal data class Strings(
     val annotated: AnnotatedString,
     val parameter: (locale: String) -> String,
     val plural: (count: Int) -> String,
-    val list: List<String>
+    val list: List<String>,
+    val nonComposeAlert:String
 )


### PR DESCRIPTION
Sometimes we may need to access strings beyond the compose framework. 

This PR makes it easy to use it if needed. Resolves https://github.com/adrielcafe/lyricist/issues/38

Do let me know what you think of it.


