### PR TITLE
Use default language strings in the XML Processor if a translation is missing

### DIFF
--- a/lyricist-processor-xml/src/main/java/cafe/adriel/lyricist/processor/xml/internal/LyricistXmlSymbolProcessor.kt
+++ b/lyricist-processor-xml/src/main/java/cafe/adriel/lyricist/processor/xml/internal/LyricistXmlSymbolProcessor.kt
@@ -57,8 +57,17 @@ internal class LyricistXmlSymbolProcessor(
             ?.let { writeStringsClassFile(fileName, stringsName, it, strings.keys) }
             ?: logger.error("Default language tag not found")
 
+        val defaultStrings = strings[config.defaultLanguageTag].orEmpty()
+
         strings.forEach { (languageTag, strings) ->
-            writeStringsPropertyFile(fileName, languageTag, strings)
+            val stringsWithMissingTranslations = if (languageTag != config.defaultLanguageTag) {
+                val notTranslatedStrings = defaultStrings.filterKeys { key -> !strings.containsKey(key) }
+                strings + notTranslatedStrings
+            } else {
+                strings
+            }
+
+            writeStringsPropertyFile(fileName, languageTag, stringsWithMissingTranslations)
         }
     }
 

--- a/sample-xml/src/main/res/values/strings.xml
+++ b/sample-xml/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="simple">Hello "world"</string>
     <string name="params">Parameters: %1$s, %2$d, %s, %d</string>
     <string name="replacement">@string/simple</string>
+    <string name="missing_translation">Missing translation</string>
 
     <string-array name="array">
         <item>Avocado</item>


### PR DESCRIPTION
Hi 👋 

I started using Lyricist, and I wanted to migrate my existing XML. However, not all the strings that I have are translated, and the processor generates the files with missing values.

I've modified the processor to generate the string file with the value from the default language if the translation is missing! 

<img width="838" alt="Screenshot 2024-03-29 at 12 26 32" src="https://github.com/adrielcafe/lyricist/assets/9467705/eeb104d8-7b6e-4c1a-8a58-39e9ed8245df">
