### PR TITLE
Add layout direction support to library

### DIFF
--- a/android-module.gradle
+++ b/android-module.gradle
@@ -27,7 +27,7 @@ android {
         kotlinCompilerExtensionVersion libs.versions.composeCompiler.get()
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,10 +3,10 @@ plugin-android = "8.2.2"
 plugin-ktlint = "12.1.0"
 plugin-maven = "0.28.0"
 
-kotlin = "1.9.22"
+kotlin = "1.9.23"
 
 coroutines = "1.8.0"
-ksp = "1.9.22-1.0.17"
+ksp = "1.9.23-1.0.20"
 caseFormat = "0.2.0"
 konsumeXml = "1.1"
 

--- a/lyricist-compose/src/commonMain/kotlin/cafe/adriel/lyricist/LyricistCompose.kt
+++ b/lyricist-compose/src/commonMain/kotlin/cafe/adriel/lyricist/LyricistCompose.kt
@@ -2,21 +2,23 @@ package cafe.adriel.lyricist
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.unit.LayoutDirection as ComposeLayoutDirection
 
 @Composable
 public fun <T> rememberStrings(
     translations: Map<LanguageTag, T>,
+    layoutDirections: Map<LanguageTag, LayoutDirection>,
     defaultLanguageTag: LanguageTag = "en",
     currentLanguageTag: LanguageTag = Locale.current.toLanguageTag()
 ): Lyricist<T> =
     remember(defaultLanguageTag) {
-        Lyricist(defaultLanguageTag, translations)
+        Lyricist(defaultLanguageTag, layoutDirections, translations)
     }.apply {
         languageTag = currentLanguageTag
     }
@@ -31,6 +33,14 @@ public fun <T> ProvideStrings(
 
     CompositionLocalProvider(
         provider provides state.strings,
+        LocalLayoutDirection provides state.layoutDirection.toComposeLayoutDirection(),
         content = content
     )
+}
+
+private fun LayoutDirection.toComposeLayoutDirection(): ComposeLayoutDirection {
+    return when (this) {
+        LayoutDirection.Ltr -> ComposeLayoutDirection.Ltr
+        LayoutDirection.Rtl -> ComposeLayoutDirection.Rtl
+    }
 }

--- a/lyricist-processor-compose/build.gradle
+++ b/lyricist-processor-compose/build.gradle
@@ -3,6 +3,7 @@ apply from: "../kotlin-module.gradle"
 dependencies {
     implementation libs.ksp
     implementation libs.caseFormat
+    implementation project(':lyricist-core')
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/lyricist-processor-compose/src/main/java/cafe/adriel/lyricist/processor/internal/LyricistSymbolProcessor.kt
+++ b/lyricist-processor-compose/src/main/java/cafe/adriel/lyricist/processor/internal/LyricistSymbolProcessor.kt
@@ -1,6 +1,5 @@
 package cafe.adriel.lyricist.processor.internal
 
-import cafe.adriel.lyricist.LayoutDirection
 import com.fleshgrinder.extensions.kotlin.toLowerCamelCase
 import com.fleshgrinder.extensions.kotlin.toUpperCamelCase
 import com.google.devtools.ksp.processing.CodeGenerator
@@ -84,13 +83,11 @@ internal class LyricistSymbolProcessor(
 
         val layoutDirectionMappingOutput = roundDeclaration
             .map {
-                val languageTag = it.annotations.getValue<String>(ANNOTATION_PARAM_LANGUAGE_TAG)
-                val layoutDirection: LayoutDirection = it.annotations.getValue<Any>(
-                    ANNOTATION_PARAM_LAYOUT_DIRECTION
-                ).getLayoutDirectionOrDefault()
+                val languageTag = it.annotations.getValue<String>(ANNOTATION_PARAM_LANGUAGE_TAG)!!
+                val layoutDirection = it.annotations.getValue<Any>(ANNOTATION_PARAM_LAYOUT_DIRECTION)!!
                 languageTag to layoutDirection
             }.joinToString(",\n") { (languageTag, layoutDirection) ->
-                "$INDENTATION\"$languageTag\" to LayoutDirection.$layoutDirection"
+                "$INDENTATION\"$languageTag\" to $layoutDirection"
             }
 
         codeGenerator.createNewFile(
@@ -216,10 +213,6 @@ internal class LyricistSymbolProcessor(
 
     private fun List<KSValueArgument>.withName(name: String): KSValueArgument? =
         firstOrNull { it.name?.getShortName() == name }
-
-    private fun Any?.getLayoutDirectionOrDefault(default: () -> LayoutDirection = { LayoutDirection.Ltr }): LayoutDirection {
-        return if (this is LayoutDirection) this else default()
-    }
 
     private companion object {
         val INDENTATION = " ".repeat(4)

--- a/lyricist-processor-xml/build.gradle
+++ b/lyricist-processor-xml/build.gradle
@@ -1,6 +1,8 @@
 apply from: "../kotlin-module.gradle"
 
 dependencies {
+    implementation(project(":lyricist-core"))
+
     implementation libs.ksp
     implementation libs.caseFormat
     implementation libs.konsumeXml

--- a/sample-multi-module/src/main/java/cafe/adriel/lyricist/sample/multimodule/strings/EnUsMultiModuleStrings.kt
+++ b/sample-multi-module/src/main/java/cafe/adriel/lyricist/sample/multimodule/strings/EnUsMultiModuleStrings.kt
@@ -1,8 +1,9 @@
 package cafe.adriel.lyricist.sample.multimodule.strings
 
+import cafe.adriel.lyricist.LayoutDirection
 import cafe.adriel.lyricist.LyricistStrings
 
-@LyricistStrings(languageTag = "en", default = true)
+@LyricistStrings(languageTag = "en", layoutDirection = LayoutDirection.Rtl, default = true)
 val EnMultiModuleStrings = MultiModuleStrings(
     string = "Hello Compose!"
 )

--- a/sample-multi-module/src/main/java/cafe/adriel/lyricist/sample/multimodule/strings/EnUsMultiModuleStrings.kt
+++ b/sample-multi-module/src/main/java/cafe/adriel/lyricist/sample/multimodule/strings/EnUsMultiModuleStrings.kt
@@ -1,9 +1,8 @@
 package cafe.adriel.lyricist.sample.multimodule.strings
 
-import cafe.adriel.lyricist.LayoutDirection
 import cafe.adriel.lyricist.LyricistStrings
 
-@LyricistStrings(languageTag = "en", layoutDirection = LayoutDirection.Rtl, default = true)
+@LyricistStrings(languageTag = "en", default = true)
 val EnMultiModuleStrings = MultiModuleStrings(
     string = "Hello Compose!"
 )

--- a/sample-multi-module/src/main/java/cafe/adriel/lyricist/sample/multimodule/strings/FaBrMultiModuleStrings.kt
+++ b/sample-multi-module/src/main/java/cafe/adriel/lyricist/sample/multimodule/strings/FaBrMultiModuleStrings.kt
@@ -1,0 +1,9 @@
+package cafe.adriel.lyricist.sample.multimodule.strings
+
+import cafe.adriel.lyricist.LayoutDirection
+import cafe.adriel.lyricist.LyricistStrings
+
+@LyricistStrings(languageTag = "fa", layoutDirection = LayoutDirection.Rtl)
+val FaMultiModuleStrings = MultiModuleStrings(
+    string = "سلام کامپوز!"
+)

--- a/sample-multi-module/src/main/java/cafe/adriel/lyricist/sample/multimodule/strings/PtBrMultiModuleStrings.kt
+++ b/sample-multi-module/src/main/java/cafe/adriel/lyricist/sample/multimodule/strings/PtBrMultiModuleStrings.kt
@@ -1,8 +1,9 @@
 package cafe.adriel.lyricist.sample.multimodule.strings
 
+import cafe.adriel.lyricist.LayoutDirection
 import cafe.adriel.lyricist.LyricistStrings
 
-@LyricistStrings(languageTag = "pt")
+@LyricistStrings(languageTag = "pt", layoutDirection = LayoutDirection.Ltr)
 val PtMultiModuleStrings = MultiModuleStrings(
     string = "Olá Compose!"
 )

--- a/sample-multiplatform/src/commonMain/kotlin/cafe/adriel/lyricist/sample/multiplatform/Application.kt
+++ b/sample-multiplatform/src/commonMain/kotlin/cafe/adriel/lyricist/sample/multiplatform/Application.kt
@@ -43,6 +43,12 @@ internal fun SampleApplication() {
                     Locales.PT,
                     Modifier.weight(1f)
                 )
+                Spacer(Modifier.weight(.1f))
+                SwitchLocaleButton(
+                    lyricist,
+                    Locales.FA,
+                    Modifier.weight(1f)
+                )
             }
         }
     }

--- a/sample-multiplatform/src/commonMain/kotlin/cafe/adriel/lyricist/sample/multiplatform/Locales.kt
+++ b/sample-multiplatform/src/commonMain/kotlin/cafe/adriel/lyricist/sample/multiplatform/Locales.kt
@@ -3,4 +3,5 @@ package cafe.adriel.lyricist.sample.multiplatform
 object Locales {
     const val EN = "en"
     const val PT = "pt"
+    const val FA = "fa"
 }

--- a/sample-multiplatform/src/commonMain/kotlin/cafe/adriel/lyricist/sample/multiplatform/strings/EnStrings.kt
+++ b/sample-multiplatform/src/commonMain/kotlin/cafe/adriel/lyricist/sample/multiplatform/strings/EnStrings.kt
@@ -5,10 +5,11 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
+import cafe.adriel.lyricist.LayoutDirection
 import cafe.adriel.lyricist.LyricistStrings
 import cafe.adriel.lyricist.sample.multiplatform.Locales
 
-@LyricistStrings(languageTag = Locales.EN, default = true)
+@LyricistStrings(languageTag = Locales.EN, layoutDirection = LayoutDirection.Ltr, default = true)
 internal val EnStrings = Strings(
     simple = "Hello Compose!",
 

--- a/sample-multiplatform/src/commonMain/kotlin/cafe/adriel/lyricist/sample/multiplatform/strings/FaStrings.kt
+++ b/sample-multiplatform/src/commonMain/kotlin/cafe/adriel/lyricist/sample/multiplatform/strings/FaStrings.kt
@@ -1,0 +1,36 @@
+package cafe.adriel.lyricist.sample.multiplatform.strings
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import cafe.adriel.lyricist.LayoutDirection
+import cafe.adriel.lyricist.LyricistStrings
+import cafe.adriel.lyricist.sample.multiplatform.Locales
+
+@LyricistStrings(languageTag = Locales.FA, layoutDirection = LayoutDirection.Rtl)
+internal val FaStrings = Strings(
+    simple = "سلام کامپوز!",
+
+    annotated = buildAnnotatedString {
+        withStyle(SpanStyle(color = Color.Red)) { append("سلام ") }
+        withStyle(SpanStyle(fontWeight = FontWeight.Light)) { append("کامپوز!") }
+    },
+
+    parameter = { locale ->
+        " زبان فعلی: $locale"
+    },
+
+    plural = { count ->
+        val value = when (count) {
+            0 -> "هیچی"
+            1, 2 -> "یک مقدار"
+            in 3..10 -> "تعدادی"
+            else -> "خیلی"
+        }
+        " من $value سیب دارم. "
+    },
+
+    list = listOf("آووکادو", "آناناس", "آلو")
+)

--- a/sample-multiplatform/src/commonMain/kotlin/cafe/adriel/lyricist/sample/multiplatform/strings/PtStrings.kt
+++ b/sample-multiplatform/src/commonMain/kotlin/cafe/adriel/lyricist/sample/multiplatform/strings/PtStrings.kt
@@ -5,10 +5,11 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
+import cafe.adriel.lyricist.LayoutDirection
 import cafe.adriel.lyricist.LyricistStrings
 import cafe.adriel.lyricist.sample.multiplatform.Locales
 
-@LyricistStrings(languageTag = Locales.PT)
+@LyricistStrings(languageTag = Locales.PT, layoutDirection = LayoutDirection.Ltr)
 internal val PtStrings = Strings(
     simple = "Olá Compose!",
 

--- a/sample-xml/src/main/res/values-fa/strings.xml
+++ b/sample-xml/src/main/res/values-fa/strings.xml
@@ -1,0 +1,20 @@
+<resources>
+    <string name="simple">سلام دنیا"</string>
+    <string name="params">پارامتر‌ها: %1$s, %2$d, %s, %d</string>
+    <string name="replacement">@string/simple</string>
+
+    <string-array name="array">
+        <item>آووکادو</item>
+        <item>آناناس</item>
+        <item>آلو</item>
+    </string-array>
+
+    <plurals name="plurals">
+        <item quantity="zero">%d صفر</item>
+        <item quantity="one">%d یک</item>
+        <item quantity="two">%d دو</item>
+        <item quantity="few">%d مقداری</item>
+        <item quantity="many">%d زیادی</item>
+        <item quantity="other">%d غیره</item>
+    </plurals>
+</resources>

--- a/sample/src/main/java/cafe/adriel/lyricist/sample/Locales.kt
+++ b/sample/src/main/java/cafe/adriel/lyricist/sample/Locales.kt
@@ -3,4 +3,5 @@ package cafe.adriel.lyricist.sample
 object Locales {
     const val EN = "en"
     const val PT = "pt"
+    const val FA = "fa"
 }

--- a/sample/src/main/java/cafe/adriel/lyricist/sample/MainActivity.kt
+++ b/sample/src/main/java/cafe/adriel/lyricist/sample/MainActivity.kt
@@ -95,6 +95,11 @@ class MainActivity : ComponentActivity() {
                         Locales.PT,
                         Modifier.weight(1f)
                     )
+                    Spacer(Modifier.weight(.1f))
+                    SwitchLocaleButton(
+                        Locales.FA,
+                        Modifier.weight(1f)
+                    )
                 }
             }
         }

--- a/sample/src/main/java/cafe/adriel/lyricist/sample/strings/FaStrings.kt
+++ b/sample/src/main/java/cafe/adriel/lyricist/sample/strings/FaStrings.kt
@@ -1,0 +1,38 @@
+package cafe.adriel.lyricist.sample.strings
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import cafe.adriel.lyricist.LayoutDirection
+import cafe.adriel.lyricist.LyricistStrings
+import cafe.adriel.lyricist.sample.Locales
+
+@LyricistStrings(languageTag = Locales.FA, layoutDirection = LayoutDirection.Rtl)
+internal val FaStrings = Strings(
+    simple = "سلام کامپوز!",
+
+    annotated = buildAnnotatedString {
+        withStyle(SpanStyle(color = Color.Red)) { append("سلام ") }
+        withStyle(SpanStyle(fontWeight = FontWeight.Light)) { append("کامپوز!") }
+    },
+
+    parameter = { locale ->
+        "زبان فعلی: $locale"
+    },
+
+    plural = { count ->
+        val value = when (count) {
+            0 -> "صفر"
+            1, 2 -> "کمی"
+            in 3..10 -> "مقداری"
+            else -> "خیلی"
+        }
+        " من $value سیب دارم! "
+    },
+
+    list = listOf("آووکادو", "آناناس", "آلو"),
+
+    nonComposeAlert = "این یک توست نمونه است",
+)

--- a/sample/src/main/java/cafe/adriel/lyricist/sample/strings/PtStrings.kt
+++ b/sample/src/main/java/cafe/adriel/lyricist/sample/strings/PtStrings.kt
@@ -5,10 +5,11 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
+import cafe.adriel.lyricist.LayoutDirection
 import cafe.adriel.lyricist.LyricistStrings
 import cafe.adriel.lyricist.sample.Locales
 
-@LyricistStrings(languageTag = Locales.PT)
+@LyricistStrings(languageTag = Locales.PT, layoutDirection = LayoutDirection.Ltr)
 internal val PtStrings = Strings(
     simple = "Olá Compose!",
 


### PR DESCRIPTION
### Add Layout Direction Support to Lyricist

#### Description:

This pull request introduces support for layout direction alongside resources in the `lyricist` library. This feature is essential for applications that need to support right-to-left (RTL) languages such as Arabic, Hebrew, and Persian. By integrating layout direction handling, developers can ensure that their applications provide a seamless and user-friendly experience for RTL language users.

**Changes Introduced:**

- Added functionality to specify layout direction (LTR or RTL) for each supported language/locale.
- Implemented automatic adjustment of UI elements based on the specified layout direction.
- Ensured seamless integration with existing resource management workflows within `lyricist`.

**Use Case:**

Consider an application that supports both English (LTR) and Arabic (RTL) languages. With this feature, developers can easily configure resources and layout direction preferences for each language, ensuring a polished and accessible experience for users regardless of their language's text direction.

**Additional Notes:**

This pull request addresses the feature request I submitted in issue #47. Initially, I implemented this feature for my own usage due to the lack of response on the issue. If this aligns with the goals of the `lyricist` project, I would be thrilled to see it merged into the main codebase. If not, please feel free to close this pull request.

Thank you for your consideration. I look forward to any feedback or suggestions you may have.

**Contact Information:**

Please feel free to reach out if further clarification or details are needed regarding this implementation.