### PR TITLE
Upgrade to Compose Multiplatform 1.10.3

### DIFF
--- a/android-module.gradle
+++ b/android-module.gradle
@@ -2,10 +2,10 @@ apply plugin: 'kotlin-android'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 
 android {
-    compileSdk 34
+    compileSdk 36
     defaultConfig {
-        minSdk 21
-        targetSdk 34
+        minSdk 23
+        targetSdk 36
         versionCode 1
         versionName "1.0"
     }
@@ -29,10 +29,10 @@ android {
         compose true
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 }

--- a/buildSrc/src/main/kotlin/Setup.kt
+++ b/buildSrc/src/main/kotlin/Setup.kt
@@ -11,14 +11,14 @@ import org.gradle.kotlin.dsl.*
 import com.android.build.gradle.LibraryExtension
 import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
-private val targetJavaVersion = JavaVersion.VERSION_1_8
-private val targetJvmVersion = JvmTarget.JVM_1_8
+private val targetJavaVersion = JavaVersion.VERSION_11
+private val targetJvmVersion = JvmTarget.JVM_11
 
 private fun BaseExtension.android() {
-    compileSdkVersion(34)
+    compileSdkVersion(36)
     defaultConfig {
-        minSdk = 21
-        targetSdk = 34
+        minSdk = 23
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-plugin-android = "8.8.2"
+plugin-android = "8.9.3"
 plugin-ktlint = "12.1.0"
 plugin-maven = "0.28.0"
 
@@ -11,8 +11,8 @@ caseFormat = "0.2.0"
 konsumeXml = "1.1"
 
 appCompat = "1.6.1"
-compose = "1.7.3"
-composeActivity = "1.8.2"
+compose = "1.10.3"
+composeActivity = "1.13.0"
 
 test-junit = "1.1.5"
 

--- a/kotlin-module.gradle
+++ b/kotlin-module.gradle
@@ -2,12 +2,12 @@ apply plugin: 'kotlin'
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
         freeCompilerArgs.add('-Xexplicit-api=strict')
     }
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }

--- a/sample-multiplatform-ios/plists/Ios/Info.plist
+++ b/sample-multiplatform-ios/plists/Ios/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/sample-multiplatform-ios/project.yml
+++ b/sample-multiplatform-ios/project.yml
@@ -17,6 +17,9 @@ targets:
       path: plists/Ios/Info.plist
       properties:
         UILaunchStoryboardName: LyricistSample
+        # Required by Compose UI, otherwise its plist sanity check crashes the
+        # app on launch on high-refresh-rate iPhones.
+        CADisableMinimumFrameDurationOnPhone: true
     settings:
       LIBRARY_SEARCH_PATHS: "$(inherited)"
       ENABLE_BITCODE: "YES"

--- a/sample-multiplatform/build.gradle.kts
+++ b/sample-multiplatform/build.gradle.kts
@@ -152,7 +152,3 @@ afterEvaluate {
         }
     }
 }
-
-compose.experimental {
-    web.application {}
-}

--- a/sample-multiplatform/src/androidMain/AndroidManifest.xml
+++ b/sample-multiplatform/src/androidMain/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:label="Voyager Sample Multiplatform"
+        android:label="@string/app_name"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/sample-multiplatform/src/androidMain/kotlin/cafe/adriel/lyricist/sample/multiplatform/SampleActivity.kt
+++ b/sample-multiplatform/src/androidMain/kotlin/cafe/adriel/lyricist/sample/multiplatform/SampleActivity.kt
@@ -2,10 +2,12 @@ package cafe.adriel.lyricist.sample.multiplatform
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 
 public class SampleActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         setContent {

--- a/sample-multiplatform/src/commonMain/kotlin/cafe/adriel/lyricist/sample/multiplatform/Application.kt
+++ b/sample-multiplatform/src/commonMain/kotlin/cafe/adriel/lyricist/sample/multiplatform/Application.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -22,7 +24,13 @@ import cafe.adriel.lyricist.strings
 internal fun SampleApplication() {
     val lyricist = rememberStrings()
     ProvideStrings(lyricist) {
-        Column {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                // Keep content clear of the status/navigation bars and the
+                // display cutout (Android is edge-to-edge from targetSdk 35+).
+                .safeDrawingPadding()
+        ) {
             SampleStrings(lyricist)
 
             Spacer(Modifier.weight(1f))

--- a/sample-multiplatform/src/desktopMain/kotlin/cafe/adriel/lyricist/sample/multiplatform/App.kt
+++ b/sample-multiplatform/src/desktopMain/kotlin/cafe/adriel/lyricist/sample/multiplatform/App.kt
@@ -5,7 +5,10 @@ import androidx.compose.ui.window.application
 
 public fun main() {
     application {
-        Window(onCloseRequest = ::exitApplication) {
+        Window(
+            onCloseRequest = ::exitApplication,
+            title = "Lyricist Sample"
+        ) {
             SampleApplication()
         }
     }

--- a/sample-multiplatform/src/jsMain/kotlin/main.js.kt
+++ b/sample-multiplatform/src/jsMain/kotlin/main.js.kt
@@ -1,15 +1,12 @@
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.window.CanvasBasedWindow
+import androidx.compose.ui.window.ComposeViewport
 import cafe.adriel.lyricist.sample.multiplatform.SampleApplication
 import org.jetbrains.skiko.wasm.onWasmReady
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
     onWasmReady {
-        CanvasBasedWindow(
-            title = "Voyager Sample",
-            canvasElementId = "ComposeTarget"
-        ) {
+        ComposeViewport(viewportContainerId = "ComposeTarget") {
             SampleApplication()
         }
     }

--- a/sample-multiplatform/src/jsMain/resources/index.html
+++ b/sample-multiplatform/src/jsMain/resources/index.html
@@ -8,9 +8,8 @@
 </head>
 <body>
 <h1>Lyricist Sample - Compose Multiplatform</h1>
-<div>
-    <canvas id="ComposeTarget" width="800" height="600"></canvas>
-</div>
+<!-- Container for ComposeViewport, which creates its own <canvas> inside (was a <canvas> when using the now-removed CanvasBasedWindow). -->
+<div id="ComposeTarget"></div>
 <script src="sample-multiplatform.js"> </script>150
 </body>
 </html>

--- a/sample-multiplatform/src/macosMain/kotlin/main.macos.kt
+++ b/sample-multiplatform/src/macosMain/kotlin/main.macos.kt
@@ -5,7 +5,7 @@ import platform.AppKit.NSApplication
 
 fun main() {
     NSApplication.sharedApplication()
-    Window("VoyagerMultiplatform") {
+    Window("Lyricist Sample") {
         SampleApplication()
     }
     NSApp?.run()

--- a/sample-multiplatform/src/wasmJsMain/kotlin/main.wasm.kt
+++ b/sample-multiplatform/src/wasmJsMain/kotlin/main.wasm.kt
@@ -1,13 +1,10 @@
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.window.CanvasBasedWindow
+import androidx.compose.ui.window.ComposeViewport
 import cafe.adriel.lyricist.sample.multiplatform.SampleApplication
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
-    CanvasBasedWindow(
-        title = "Voyager Sample",
-        canvasElementId = "ComposeTarget"
-    ) {
+    ComposeViewport(viewportContainerId = "ComposeTarget") {
         SampleApplication()
     }
 }

--- a/sample-multiplatform/src/wasmJsMain/resources/index.html
+++ b/sample-multiplatform/src/wasmJsMain/resources/index.html
@@ -8,9 +8,8 @@
 </head>
 <body>
 <h1>Lyricist Sample - Compose Multiplatform</h1>
-<div>
-    <canvas id="ComposeTarget" width="800" height="600"></canvas>
-</div>
+<!-- Container for ComposeViewport, which creates its own <canvas> inside (was a <canvas> when using the now-removed CanvasBasedWindow). -->
+<div id="ComposeTarget"></div>
 <script src="sample-multiplatform.js"> </script>150
 </body>
 </html>


### PR DESCRIPTION
## Summary

Upgrades Compose Multiplatform (and the aligned androidx Compose artifacts) from **1.7.3 → 1.10.3**, staying on **Kotlin 2.2.21**.

### Why 1.10.3 and not 1.11.x

CMP **1.11.x requires Kotlin 2.3.20** for the Kotlin/JS and Kotlin/Wasm targets — its web/native klibs are built with Kotlin 2.3.x and cannot be read by Kotlin 2.2.x. On 1.11.1 the JVM/Android targets compile, but `compileKotlinJs`/`compileKotlinWasmJs` fail with unresolved `androidx.compose.*` references (klib ABI incompatibility). **1.10.3 is the newest CMP that works on Kotlin 2.2.21 across every target** while still being a substantial jump from 1.7.3. (The CMP Gradle plugin also caps the 1.10.x line at 1.10.3.)

## Changes

- `gradle/libs.versions.toml`:
  - `compose 1.7.3 → 1.10.3` (unified for the CMP plugin and the androidx `runtime`/`ui-text`/`material` artifacts).
  - AGP `8.8.2 → 8.9.3` (compileSdk 36 is a tested level here, so no suppression flag is needed).
  - `activity-compose 1.8.2 → 1.13.0` (sample-only — see the scope note below).
- `buildSrc/Setup.kt` + `android-module.gradle`: `compileSdk`/`targetSdk 34 → 36`, `minSdk 21 → 23`, JVM target `1.8 → 11`.
  - minSdk 23 is required: `compose-ui`/`foundation`/`material` 1.10.x declare `minSdkVersion 23`, so the sample manifest merge fails at 21.
- `kotlin-module.gradle`: JVM target `1.8 → 11` for the processor modules.
- Sample (kept compiling — no feature changes):
  - `sample-multiplatform` JS/Wasm entry points: migrate from the now error-level-deprecated `CanvasBasedWindow` to `ComposeViewport`, and switch the web container from a `<canvas>` to a `<div>` (`ComposeViewport` creates its own canvas inside the container).
  - Remove the obsolete `compose.experimental { web.application {} }` block (removed in CMP ≥ 1.8; web is configured directly via the `js`/`wasmJs` `browser()` targets).

The Apple x86_64 targets (`iosX64`, `macosX64`) are **kept** — those are only removed in CMP 1.11.0.

### Dependency-scope note

`activity-compose`, `material` and `appCompat` are **sample-only** — the published libraries do not ship them. `lyricist-core` depends only on `kotlinx-coroutines`; `lyricist-compose` depends on `lyricist-core` + `kotlinx-coroutines` and takes Compose `runtime`/`ui` as `compileOnly` (not exposed transitively). So the `activity-compose` bump has no effect on the library's published dependency contract; it also resolves cleanly, keeping Compose `runtime`/`ui`/`material` at 1.10.3.

## Evidence

**Mobile & native**

| iOS | Android | macOS (Apple Silicon) |
|:---:|:---:|:---:|
| <video src="https://github.com/user-attachments/assets/217506b4-10e6-4be4-b3f3-ddc28aba2f62" width="220" controls></video> | <video src="https://github.com/user-attachments/assets/b9d11290-78eb-44c8-a2ce-991c037bbdf5" width="220" controls></video> | <video src="https://github.com/user-attachments/assets/d1854be3-3a93-4e2d-bdcb-7b3fd0538afe" width="220" controls></video> |

**Desktop & web**

| Desktop (JVM) | Wasm | Kotlin/JS |
|:---:|:---:|:---:|
| <video src="https://github.com/user-attachments/assets/2157b4c7-d915-49ce-9be5-8c7e04497725" width="220" controls></video> | <video src="https://github.com/user-attachments/assets/20ae3b2d-b3d7-4d80-80c7-2471c1e779ab" width="220" controls></video> | <video src="https://github.com/user-attachments/assets/e089848c-a815-4e21-93d3-6a16eb2bbb44" width="220" controls></video> |
